### PR TITLE
Fixed pretty-printing of negation operator leaving out parentheses

### DIFF
--- a/ex2.py
+++ b/ex2.py
@@ -96,7 +96,7 @@ def pretty(tree, subst={}, paren=False):
         }[op]
         return par('{} {} {}'.format(lhs, c, rhs))
     elif op == 'neg':
-        sub = pretty(tree.children[0], subst)
+        sub = pretty(tree.children[0], subst, True)
         return '-{}'.format(sub, True)
     elif op == 'num':
         return tree.children[0]


### PR DESCRIPTION
Just a small fix for pretty-printing that fixes equations like `-(a + b)` being printed as `-a + b` (similarly, `-(1 ? a : b)` being printing as `-1 ? a : b`) that I ran into during the program synthesis assignment.